### PR TITLE
Add missing parts of PropensityComputer

### DIFF
--- a/prepostprocessing/PropensityComputer.java
+++ b/prepostprocessing/PropensityComputer.java
@@ -60,9 +60,9 @@ public class PropensityComputer {
 		PropensityComputer pc = new PropensityComputer();
 		
 		double A = 0.55 ; double B = 1.5; 
-		String inputFile = "../train-remapped-tfidf-relabeled.txt";
-		String propFile =  "../inv_prop.txt";
-		
+		String inputFile = args[0];
+		String propFile =  args[1];
+
 		long totalInstances = 15511; //eurlex
 		
 		SamplesPerClassCounter spcc = new SamplesPerClassCounter();

--- a/readme.txt
+++ b/readme.txt
@@ -69,11 +69,14 @@ Performance evaluation (in Java)
 Computation of Precision@k and nDCG@k for k=1,3,5
 Now, we need to get final top-1, top-3 and top-5 from the output of individual models. This is done by the following :
 
-****** IMPORTANT : Change the number of test points in DistributedPredictor.java (at line number 138) based on number of test points in the datasets ******
+javac PropensityComputer.java
+java PropensityComputer ../eurlex/train-remapped-tfidf-relabeled.txt ../eurlex/inv_prop.txt
+
+****** IMPORTANT : Change the number of test points in DistributedPredictor.java (at line number 375) based on number of test points in the datasets ******
 
 mkdir ../eurlex/final-output
 javac DistributedPredictor.java
-java DistributedPredictor ../eurlex/output/ ../eurlex/final-output/top1.out ../eurlex/final-output/top3.out ../eurlex/final-output/top5.out ../eurlex/final-output/top1-prop.out ../eurlex/final-output/top3-prop.out ../eurlex/final-output/top5-prop.out
+java DistributedPredictor ../eurlex/output/ ../eurlex/final-output/top1.out ../eurlex/final-output/top3.out ../eurlex/final-output/top5.out ../eurlex/inv_prop.txt ../eurlex/final-output/top1-prop.out ../eurlex/final-output/top3-prop.out ../eurlex/final-output/top5-prop.out
 
 javac MultiLabelMetrics.java
 java MultiLabelMetrics ../eurlex/GS.txt ../eurlex/final-output/top1.out ../eurlex/final-output/top3.out ../eurlex/final-output/top5.out ../eurlex/inv_prop.txt ../eurlex/final-output/top1-prop.out ../eurlex/final-output/top3-prop.out ../eurlex/final-output/top5-prop.out


### PR DESCRIPTION
The instructions for PropensityComputer is missing in readme.txt.
Also, the line number for the number of test samples is corrected.